### PR TITLE
more tolerant regex

### DIFF
--- a/coffee/templaterState.coffee
+++ b/coffee/templaterState.coffee
@@ -56,7 +56,7 @@ module.exports=class TemplaterState
 			@loopOpen={'start':@tagStart,'end':@tagEnd,'tag':@textInsideTag.substr 1}
 		if @textInsideTag[0]=='-' and @loopType()=='simple'
 			@inDashLoop= true
-			dashInnerRegex= /^-([a-zA-Z_:]+) ([a-zA-Z_:]+)$/
+			dashInnerRegex= /^-([^\s]+)\s(.+)$/
 			@loopOpen={'start':@tagStart,'end':@tagEnd,'tag':(@textInsideTag.replace dashInnerRegex, '$2'),'element':(@textInsideTag.replace dashInnerRegex, '$1')}
 		if @textInsideTag[0]=='/'
 			@loopClose={'start':@tagStart,'end':@tagEnd}


### PR DESCRIPTION
allows for parsing tags with additional spaces, such as complex angular expressions: `{-w:p text | split:'\n'}{.}{/text | split:'\n'}`
