### PR TITLE
fix issue #165

### DIFF
--- a/coffee/docxTemplater.coffee
+++ b/coffee/docxTemplater.coffee
@@ -6,6 +6,7 @@ DocXTemplater = class DocXTemplater extends XmlTemplater
 		super("",options)
 		@currentClass=DocXTemplater
 		@tagXml='w:t'
+		@tagRawXml='w:p'
 		if typeof content=="string" then @load content else throw new Error("content must be string!")
 	calcIntellegentlyDashElement:()->
 		{content,start,end}= @templaterState.findOuterTagsContent(@content)

--- a/coffee/pptxTemplater.coffee
+++ b/coffee/pptxTemplater.coffee
@@ -6,6 +6,7 @@ PptXTemplater = class PptXTemplater extends XmlTemplater
 		super(content,options)
 		@currentClass=PptXTemplater
 		@tagXml='a:t'
+		@tagRawXml='p:sp'
 		if typeof content=="string" then @load content else throw new Error("content must be string!")
 	xmlToBeReplaced:(noStartTag, spacePreserve, insideValue,xmlTagNumber,noEndTag)->
 		if noStartTag == true

--- a/coffee/xmlTemplater.coffee
+++ b/coffee/xmlTemplater.coffee
@@ -9,6 +9,7 @@ ModuleManager=require('./moduleManager')
 module.exports=class XmlTemplater #abstract class !!
 	constructor: (content="",options={}) ->
 		@tagXml='' #tagXml represents the name of the tag that contains text. For example, in docx, @tagXml='w:t'
+		@tagRawXml='' #tagRawXml represents the name of the tag that needs to be replaced when embedding raw XML using `{@rawXml}`.
 		@currentClass=XmlTemplater #This is used because tags are recursive, so the class needs to be able to instanciate an object of the same class. I created a variable so you don't have to Override all functions relative to recursivity
 		@fromJson(options)
 		@templaterState= new TemplaterState @moduleManager
@@ -99,7 +100,7 @@ module.exports=class XmlTemplater #abstract class !!
 		@content=@replaceTagByValue(DocUtils.utf8ToWord(newValue),@content)
 	replaceSimpleTagRawXml:()->
 		newText=@scopeManager.getValueFromScope(@templaterState.tag)
-		subContent=new SubContent(@content).getInnerTag(@templaterState).getOuterXml('w:p')
+		subContent=new SubContent(@content).getInnerTag(@templaterState).getOuterXml(@tagRawXml)
 		@replaceXml(subContent,newText)
 	replaceXml:(subContent,newText)->
 		@templaterState.moveCharacters(@templaterState.tagStart.numXmlTag,newText.length,subContent.text.length)


### PR DESCRIPTION
This PR fixes the issue and makes usable the raw XML within PPTX. The only issue is that it aggressively replace the entire placeholder and as such it also removes its coordinates. This works for my use case but you might want to consider to pass the outer-element-tag to be replaced as an option.