### PR TITLE
getTempaltedFilesFullText

### DIFF
--- a/es6/docxtemplater.js
+++ b/es6/docxtemplater.js
@@ -99,6 +99,17 @@ var Docxtemplater = class Docxtemplater {
 	getFullText(path) {
 		return this.createTemplateClass(path || this.fileTypeConfig.textPath).getFullText();
 	}
+	getTemplatedFilesFullText() {
+		var templatedFilesText = {};
+		var iterable = this.templatedFiles;
+		for (var i = 0, fileName; i < iterable.length; i++) {
+			fileName = iterable[i];
+			if ((this.zip.files[fileName] != null)) {
+				templatedFilesText[fileName] = this.getFullText(fileName);
+			}
+		}
+		return templatedFilesText;
+	}
 };
 
 Docxtemplater.DocUtils = require("./docUtils");

--- a/es6/docxtemplater.js
+++ b/es6/docxtemplater.js
@@ -99,16 +99,8 @@ var Docxtemplater = class Docxtemplater {
 	getFullText(path) {
 		return this.createTemplateClass(path || this.fileTypeConfig.textPath).getFullText();
 	}
-	getTemplatedFilesFullText() {
-		var templatedFilesText = {};
-		var iterable = this.templatedFiles;
-		for (var i = 0, fileName; i < iterable.length; i++) {
-			fileName = iterable[i];
-			if ((this.zip.files[fileName] != null)) {
-				templatedFilesText[fileName] = this.getFullText(fileName);
-			}
-		}
-		return templatedFilesText;
+	getTemplatedFiles() {
+		return this.templatedFiles;
 	}
 };
 

--- a/es6/tests/docxtemplater.js
+++ b/es6/tests/docxtemplater.js
@@ -158,6 +158,15 @@ function startTest() {
 				var fullText = (docX["imageExample.docx"].getFullText());
 				expect(fullText).to.be.equal("");
 			});
+			it("should load the right content for all the templated files", function () {
+				// default value document.xml
+				var fullTexts = (docX["tagExample.docx"].getTemplatedFilesFullText());
+				expect(fullTexts).to.be.eql({
+					"word/document.xml": "{last_name} {first_name}",
+					"word/footer1.xml": "{last_name}{first_name}{phone}",
+					"word/header1.xml": "{last_name} {first_name}{phone}{description}",
+				});
+			});
 		});
 		describe("output and input", function () {
 			it("should be the same", function () {

--- a/es6/tests/docxtemplater.js
+++ b/es6/tests/docxtemplater.js
@@ -158,14 +158,10 @@ function startTest() {
 				var fullText = (docX["imageExample.docx"].getFullText());
 				expect(fullText).to.be.equal("");
 			});
-			it("should load the right content for all the templated files", function () {
+			it("should load the right template files for the document", function () {
 				// default value document.xml
-				var fullTexts = (docX["tagExample.docx"].getTemplatedFilesFullText());
-				expect(fullTexts).to.be.eql({
-					"word/document.xml": "{last_name} {first_name}",
-					"word/footer1.xml": "{last_name}{first_name}{phone}",
-					"word/header1.xml": "{last_name} {first_name}{phone}{description}",
-				});
+				var templatedFiles = (docX["tagExample.docx"].getTemplatedFiles());
+				expect(templatedFiles).to.be.eql(["word/header1.xml", "word/footer1.xml", "word/document.xml"]);
 			});
 		});
 		describe("output and input", function () {

--- a/es6/tests/docxtemplater.js
+++ b/es6/tests/docxtemplater.js
@@ -159,7 +159,6 @@ function startTest() {
 				expect(fullText).to.be.equal("");
 			});
 			it("should load the right template files for the document", function () {
-				// default value document.xml
 				var templatedFiles = (docX["tagExample.docx"].getTemplatedFiles());
 				expect(templatedFiles).to.be.eql(["word/header1.xml", "word/footer1.xml", "word/document.xml"]);
 			});


### PR DESCRIPTION
Hi,

I'm working on an application where the tags contained in a docx file are unknown. I've been relying on `#getFullText` to find the tags, but now I'm dealing with the possibility for tags being in the headers and/or footer.

I realize that I can use something like `getFullText('word/header1.xml')`, but sometimes there's more than one header file, and I'd rather not directly access the `templatedFiles` property of Docxtemplater. 

Here are some other implementations I considered and would gladly rewrite if you like one better. I choose the one I did because it seemed the most general.

- Add `#getFooterText` and `#getHeaderText` (maybe throw a 'not implemented' error if filetype is pptx')

- Add `#getTemplatedFiles`

- Add `#getAllFullText`, which takes all the text from the templated files and concatenates them

- Change `#getFullText`to be as `#getAllFullText` was described above

Thank You,
Porter