### PR TITLE
Add image support in CLI interface

### DIFF
--- a/es6/cli.js
+++ b/es6/cli.js
@@ -46,7 +46,7 @@ if (DocUtils.config.modules && DocUtils.config.modules.indexOf("docxtemplater-im
 	sizeOf = require("image-size");
 }
 
-const imageDir = path.resolve(process.cwd(), DocUtils.config.imageDir || '') + path.sep;
+const imageDir = path.resolve(process.cwd(), DocUtils.config.imageDir || "") + path.sep;
 const inputFileName = DocUtils.config.inputFile;
 const fileType = inputFileName.indexOf(".pptx") !== -1 ? "pptx" : "docx";
 const jsonFileName = process.argv[2];
@@ -78,7 +78,7 @@ if (ImageModule && sizeOf) {
 
 	opts.getImage = function (tagValue) {
 		const filePath = path.resolve(imageDir, tagValue);
-		console.log('path' + filePath);
+
 		if (filePath.indexOf(imageDir) !== 0) {
 			throw new Error("Images must be stored under folder: " + imageDir);
 		}

--- a/es6/cli.js
+++ b/es6/cli.js
@@ -10,6 +10,8 @@ const JSZip = require("jszip");
 const DocUtils = require("./doc-utils");
 const Docxtemplater = require("./docxtemplater");
 const fileExts = ["pptx", "docx"];
+const ImageModule = require("docxtemplater-image-module");
+const sizeOf = require("image-size");
 
 function showHelp() {
 	console.info("Usage: docxtemplater <configFilePath>");
@@ -56,9 +58,26 @@ if (debugBool) {
 if (debugBool) {
 	console.info("loading docx:" + inputFileName);
 }
+
+let opts = {};
+opts.centered = false;
+opts.fileType = fileType;
+
+opts.getImage=function(tagValue, tagName) {
+	return fs.readFileSync(tagValue, "binary");
+}
+
+opts.getSize=function(img, tagValue, tagName) {
+	const dimensions = sizeOf(tagValue);
+	return [dimensions.width, dimensions.height];
+}
+
+var imageModule = new ImageModule(opts);
 const content = fs.readFileSync(currentPath + inputFileName, "binary");
 const zip = new JSZip(content);
-const doc = new Docxtemplater().loadZip(zip);
+const doc = new Docxtemplater();
+doc.attachModule(imageModule);
+doc.loadZip(zip);
 doc.setOptions({fileType});
 doc.setData(jsonInput);
 doc.render();

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "url": "https://github.com/open-xml-templating/docxtemplater"
   },
   "dependencies": {
+    "docxtemplater-image-module": "^3.0.0",
+    "image-size": "^0.5.0",
     "xmldom": "^0.1.22"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,6 @@
     "url": "https://github.com/open-xml-templating/docxtemplater"
   },
   "dependencies": {
-    "docxtemplater-image-module": "^3.0.0",
-    "image-size": "^0.5.0",
     "xmldom": "^0.1.22"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello,

I worked on adding image support to CLI
Image size is taken from the image file itself

Because we can't really set the opt.centered = true flag from CLI. We use the tag {%%image} in documents instead.

Regards,
Maxime
