### PR TITLE
Add support for PPTX documents in test utils method 'shouldBeSame'

### DIFF
--- a/es6/tests/utils.js
+++ b/es6/tests/utils.js
@@ -41,7 +41,7 @@ function shouldBeSame(options) {
 	}
 
 	try {
-		expectedZip = docX[expectedName].zip;
+		expectedZip = (docX[expectedName]) ? docX[expectedName].zip : pptX[expectedName].zip;
 	}
 	catch (e) {
 		console.log(JSON.stringify({msg: "Expected name does not match", expectedName}));


### PR DESCRIPTION
Hello,

Fixed some code where there was a lack of PPTX support. With this the tests on docxtemplater-image-module should work.

Regards,
Maxime