### PR TITLE
Fix code block in syntax.rst

### DIFF
--- a/docs/source/syntax.rst
+++ b/docs/source/syntax.rst
@@ -92,6 +92,7 @@ allows optional fields in your data. For example, this template:
 and this data: 
 
 .. code-block:: javascript
+
     {
         people: 
             [


### PR DESCRIPTION
Simply adds a newline such that the javascript code block will render.