### PR TITLE
Extended scope for iterations

### DIFF
--- a/es6/modules/loop.js
+++ b/es6/modules/loop.js
@@ -42,8 +42,8 @@ const loopModule = {
 			return null;
 		}
 		const totalValue = [];
-		function loopOver(scope) {
-			const scopeManager = options.scopeManager.createSubScopeManager(scope, part.value);
+		function loopOver(scope, metadata) {
+			const scopeManager = options.scopeManager.createSubScopeManager(scope, part.value, metadata);
 			totalValue.push(options.render(
 				DocUtils.mergeObjects({}, options, {
 					compiled: part.subparsed,

--- a/es6/scope-manager.js
+++ b/es6/scope-manager.js
@@ -29,6 +29,12 @@ const ScopeManager = class ScopeManager {
 		if (type === "[object Array]") {
 			for (let i = 0, scope; i < value.length; i++) {
 				scope = value[i];
+				
+				if (Object.prototype.toString.call(scope) === "[object Object]") {
+					scope.$index = i;
+					scope.$last = (value.length - 1 === i);
+				}
+
 				this.functorIfInverted(!inverted, functor, scope);
 			}
 			return;

--- a/es6/scope-manager.js
+++ b/es6/scope-manager.js
@@ -29,12 +29,7 @@ const ScopeManager = class ScopeManager {
 		if (type === "[object Array]") {
 			for (let i = 0, scope; i < value.length; i++) {
 				scope = value[i];
-				
-				if (Object.prototype.toString.call(scope) === "[object Object]") {
-					scope.$index = i;
-					scope.$last = (value.length - 1 === i);
-				}
-
+				this.extendScope(scope, i, value.length);
 				this.functorIfInverted(!inverted, functor, scope);
 			}
 			return;
@@ -44,6 +39,12 @@ const ScopeManager = class ScopeManager {
 		}
 		if (value === true) {
 			return this.functorIfInverted(!inverted, functor, currentValue);
+		}
+	}
+	extendScope(scope, index, arrayLength) {
+		if (Object.prototype.toString.call(scope) === "[object Object]") {
+			scope.$index = index;
+			scope.$last = (arrayLength - 1 === index);
 		}
 	}
 	getValue(tag, num) {

--- a/es6/scope-manager.js
+++ b/es6/scope-manager.js
@@ -1,5 +1,7 @@
 "use strict";
 const Errors = require("./errors");
+const DocUtils = require("./doc-utils");
+
 
 // This class responsibility is to manage the scope
 const ScopeManager = class ScopeManager {
@@ -12,9 +14,9 @@ const ScopeManager = class ScopeManager {
 		inverted = inverted || false;
 		return this.loopOverValue(this.getValue(tag), callback, inverted);
 	}
-	functorIfInverted(inverted, functor, value) {
+	functorIfInverted(inverted, functor, value, metadata) {
 		if (inverted) {
-			functor(value);
+			functor(value, metadata);
 		}
 	}
 	isValueFalsy(value, type) {
@@ -28,9 +30,13 @@ const ScopeManager = class ScopeManager {
 		}
 		if (type === "[object Array]") {
 			for (let i = 0, scope; i < value.length; i++) {
+				let loop = { 
+					last: (value.length - 1 === i), 
+					index: i 
+				};
 				scope = value[i];
-				this.extendScope(scope, i, value.length);
-				this.functorIfInverted(!inverted, functor, scope);
+
+				this.functorIfInverted(!inverted, functor, scope, { loop });
 			}
 			return;
 		}
@@ -39,12 +45,6 @@ const ScopeManager = class ScopeManager {
 		}
 		if (value === true) {
 			return this.functorIfInverted(!inverted, functor, currentValue);
-		}
-	}
-	extendScope(scope, index, arrayLength) {
-		if (Object.prototype.toString.call(scope) === "[object Object]") {
-			scope.$index = index;
-			scope.$last = (arrayLength - 1 === index);
 		}
 	}
 	getValue(tag, num) {
@@ -84,11 +84,13 @@ const ScopeManager = class ScopeManager {
 		if (result == null && this.num > 0) { return this.getValue(tag, this.num - 1); }
 		return result;
 	}
-	createSubScopeManager(scope, tag) {
+	createSubScopeManager(scope, tag, metadata) {
 		const options = {
 			scopePath: this.scopePath.slice(0),
 			scopeList: this.scopeList.slice(0),
 		};
+
+		scope = DocUtils.mergeObjects(metadata || {}, scope);
 
 		options.parser = this.parser;
 		options.scopeList = this.scopeList.concat(scope);


### PR DESCRIPTION
Purpose:

It is useful to be able to track the index when iterating over an array of object. Common use case is when the text is connected by a conjuncture that should not be there after the last item. Example:

{#people}{name}{^last}, {/#}{/#}

Where "people" might be an array such as [{name: 'Anna'}, {name: 'Sophia'}] and the result would be: Anna, Sophia