### PR TITLE
feat: change the constructor to the new v4 api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### 3.17.0
 
-- Add constructor method that accepts zip and optionally modules. This constructor will be the official constructor in docxtemplater v4, and the methods : `loadZip`, `attachModule` and `compile` will no more be available. 
+- Add a constructor method that accepts zip and optionally modules. This constructor will be the official constructor in docxtemplater v4 and the methods: `loadZip`, `attachModule` and `compile` will no more be available. 
+
+You can migrate the following code:
 
 ```
 const doc = new Docxtemplater();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 3.17.0
+
+- Change the Docxtemplater constructor to accept zip and modules as part of arguments. It is now possible to call `new Docxtemplater(zip)` instead of `new Docxtemplater().loadZip(zip)`
+- This is a backward compatible change
+
 ### 3.16.11
 
 - Add specific error (`Duplicate open tag` and `Duplicate close tag`) when using `{{foobar}}` in a template when the delimiters are just one single `{` and `}`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,35 @@
 ### 3.17.0
 
-- Change the Docxtemplater constructor to accept zip and modules as part of arguments. It is now possible to call `new Docxtemplater(zip)` instead of `new Docxtemplater().loadZip(zip)`
-- This is a backward compatible change
+- Add constructor method that accepts zip and optionally modules. This constructor will be the official constructor in docxtemplater v4, and the methods : `loadZip`, `attachModule` and `compile` will no more be available. 
+
+```
+const doc = new Docxtemplater();
+doc.loadZip(zip)
+doc.attachModule(new ImageModule())
+doc.attachModule(new Htmlmodule())
+doc.attachModule(new Pptxmodule())
+try {
+    doc.compile();
+}
+catch (e) {
+     // error handler
+}
+```
+
+to
+
+```
+try {
+   const doc = new Docxtemplater(zip, {
+          modules: [new ImageModule(), new Htmlmodule(), new Pptxmodule()]
+    });
+}
+catch (e) {
+     // error handler
+}
+```
+
+- This change is backward compatible, meaning that you can continue to use the constructor with no arguments for the time being.
 
 ### 3.16.11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 ### 3.17.0
 
-- Add a constructor method that accepts zip and optionally modules. This constructor will be the official constructor in docxtemplater v4 and the methods: `loadZip`, `attachModule` and `compile` will no more be available. 
+- Add a constructor method that accepts zip and optionally modules and other options. This constructor will be the official constructor in docxtemplater v4 and the methods: `loadZip`, `attachModule`, `setOptions` and `compile` will no more be available. 
 
 You can migrate the following code:
 
 ```
 const doc = new Docxtemplater();
 doc.loadZip(zip)
+doc.setOptions({
+    delimiters: {
+      start: "<",
+      end: ">",
+    },
+});
 doc.attachModule(new ImageModule())
 doc.attachModule(new Htmlmodule())
 doc.attachModule(new Pptxmodule())
@@ -21,10 +27,15 @@ catch (e) {
 to
 
 ```
+const options = {
+    modules: [new ImageModule(), new Htmlmodule(), new Pptxmodule()],
+    delimiters: {
+      start: "<",
+      end: ">",
+    },
+}
 try {
-   const doc = new Docxtemplater(zip, {
-          modules: [new ImageModule(), new Htmlmodule(), new Pptxmodule()]
-    });
+   const doc = new Docxtemplater(zip, options);
 }
 catch (e) {
      // error handler

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -19,14 +19,14 @@ Constructor
 
     new Docxtemplater(zip, options)
 
-        You have to pass both the parameters if you are using this constructor.
+        You have to pass a valid zip file to use this constructor. You can pass an array of modules that are needed by templater to attach them at the time of instantiating.
 
             zip:
                 a zip instance to that method, coming from pizzip or jszip version 2.
 
-            options:
-                An options object should have a modules key has a value of an array consisting of the modules.
-                For eg: { modules: [exampleModule, otherModule] }
+            options: (optional)
+                Currently, It supports the ability to add modules. You can attach modules by calling the Docxtemplater like this
+                const doc = new Docxtemplater(zip, { modules: [exampleModule, otherModule] })
                 
         This function returns a new Docxtemplater Object 
 
@@ -49,6 +49,10 @@ Methods
     render()
 
         This function replaces all template variables by their values
+
+    compile()
+
+        This function parses the template to prepare for the rendering. If your template has some issues in the syntax (for example if your tag is never closed like in : `Hello {user`), this function will throw an error with extra properties describing the error. This function is called for you in render() if you didn't call it yourself. This function should be called before doing resolveData() if you have some async data.
 
     getZip()
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -15,6 +15,21 @@ Constructor
 
         This function returns a new Docxtemplater Object
 
+.. code-block:: text
+
+    new Docxtemplater(zip, options)
+
+        You have to pass both the parameters if you are using this constructor.
+
+            zip:
+                a zip instance to that method, coming from pizzip or jszip version 2.
+
+            options:
+                An options object should have a modules key has a value of an array consisting of the modules.
+                For eg: { modules: [exampleModule, otherModule] }
+                
+        This function returns a new Docxtemplater Object 
+
 
 Methods
 -------

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -36,9 +36,9 @@ Constructor
                 const options = {
                     modules: [ new ImageModule(imageOpts) ],
                     delimiters: {
-				start: "<",
-				end: ">",
-		    },
+                        start: "<",
+                        end: ">",
+                    },
                 }
                 const doc = new Docxtemplater(zip, options);
                 
@@ -74,7 +74,7 @@ Methods
 
     setOptions()
 
-         This function is used to configure the docxtemplater instance by changing parser, delimiters, etc. You can read more about it here (https://docxtemplater.readthedocs.io/en/latest/configuration.html).
+         This function is used to configure the docxtemplater instance by changing parser, delimiters, etc. (See https://docxtemplater.readthedocs.io/en/latest/configuration.html).
 
     attachModule(module)
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -17,16 +17,19 @@ Constructor
 
 .. code-block:: text
 
-    new Docxtemplater(zip, options)
+    new Docxtemplater(zip[, options])
 
-        You have to pass a valid zip file to use this constructor. You can pass an array of modules that are needed by templater to attach them at the time of instantiating.
-
+        This constructor is preferred over the constructor without any arguments. The constructor without arguments will be removed in docxtemplater version 4.
+        When calling the constructor with a zip file as the first argument, the document will be compiled during instantiation, meaning that this will throw an error if some tag is misplaced in your document.
+        The options parameter allows you to attach some modules, and they will be attached before compilation.
+        
             zip:
                 a zip instance to that method, coming from pizzip or jszip version 2.
 
-            options: (optional)
-                Currently, It supports the ability to add modules. You can attach modules by calling the Docxtemplater like this
-                const doc = new Docxtemplater(zip, { modules: [exampleModule, otherModule] })
+            options: (default {modules:[]})
+                You can pass the list of modules that you would like to attach.
+                For example :
+                const doc = new Docxtemplater(zip, { modules: [ new ImageModule(imageOpts) ] });
                 
         This function returns a new Docxtemplater Object 
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -27,9 +27,20 @@ Constructor
                 a zip instance to that method, coming from pizzip or jszip version 2.
 
             options: (default {modules:[]})
-                You can pass the list of modules that you would like to attach.
+                You can use this object to configure docxtemplater. It is possible to configure in the following ways:
+
+                    * You can pass options to change custom parser, custom delimiters, etc.
+                    * You can pass the list of modules that you would like to attach.
+
                 For example :
-                const doc = new Docxtemplater(zip, { modules: [ new ImageModule(imageOpts) ] });
+                const options = {
+                    modules: [ new ImageModule(imageOpts) ],
+                    delimiters: {
+				start: "<",
+				end: ">",
+		    },
+                }
+                const doc = new Docxtemplater(zip, options);
                 
         This function returns a new Docxtemplater Object 
 
@@ -60,6 +71,10 @@ Methods
     getZip()
 
         This will return you the zip that represents the docx. You can then call `.generate` on this to generate a buffer, string , ... (see https://github.com/open-xml-templating/pizzip/blob/master/documentation/api_pizzip/generate.md)
+
+    setOptions()
+
+         This function is used to configure the docxtemplater instance by changing parser, delimiters, etc. You can read more about it here (https://docxtemplater.readthedocs.io/en/latest/configuration.html).
 
     attachModule(module)
 

--- a/docs/source/generate.rst
+++ b/docs/source/generate.rst
@@ -25,8 +25,7 @@ Node
 
     var zip = new PizZip(content);
 
-    var doc = new Docxtemplater();
-    doc.loadZip(zip);
+    var doc = new Docxtemplater(zip);
 
     //set the templateVariables
     doc.setData({
@@ -101,7 +100,7 @@ Browser
             loadFile("https://docxtemplater.com/tag-example.docx",function(error,content){
                 if (error) { throw error };
                 var zip = new PizZip(content);
-                var doc=new window.docxtemplater().loadZip(zip)
+                var doc=new window.docxtemplater(zip);
                 doc.setData({
                     first_name: 'John',
                     last_name: 'Doe',

--- a/docs/source/generate.rst
+++ b/docs/source/generate.rst
@@ -47,17 +47,18 @@ Node
         errorHandler(error);
     }
 
-    function errorHandler(error) {
-        // The error thrown here contains additional information when logged with JSON.stringify (it contains a properties object containing all suberrors).
-        function replaceErrors(key, value) {
-            if (value instanceof Error) {
-                return Object.getOwnPropertyNames(value).reduce(function(error, key) {
-                    error[key] = value[key];
-                    return error;
-                }, {});
-            }
-            return value;
+    // The error thrown here contains additional information when logged with JSON.stringify (it contains a properties object containing all suberrors).
+    function replaceErrors(key, value) {
+        if (value instanceof Error) {
+            return Object.getOwnPropertyNames(value).reduce(function(error, key) {
+                error[key] = value[key];
+                return error;
+            }, {});
         }
+        return value;
+    }
+
+    function errorHandler(error) {
         console.log(JSON.stringify({error: error}, replaceErrors));
 
         if (error.properties && error.properties.errors instanceof Array) {
@@ -130,16 +131,6 @@ Browser
                 }
 
                 function errorHandler(error) {
-                    // The error thrown here contains additional information when logged with JSON.stringify (it contains a properties object containing all suberrors).
-                    function replaceErrors(key, value) {
-                        if (value instanceof Error) {
-                            return Object.getOwnPropertyNames(value).reduce(function(error, key) {
-                                error[key] = value[key];
-                                return error;
-                            }, {});
-                        }
-                        return value;
-                    }
                     console.log(JSON.stringify({error: error}, replaceErrors));
 
                     if (error.properties && error.properties.errors instanceof Array) {
@@ -151,6 +142,17 @@ Browser
                         // 'The tag beginning with "foobar" is unopened'
                     }
                     throw error;
+                }
+
+                // The error thrown here contains additional information when logged with JSON.stringify (it contains a properties object containing all suberrors).
+                function replaceErrors(key, value) {
+                    if (value instanceof Error) {
+                        return Object.getOwnPropertyNames(value).reduce(function(error, key) {
+                            error[key] = value[key];
+                            return error;
+                        }, {});
+                    }
+                    return value;
                 }
 
                 var out=doc.getZip().generate({

--- a/docs/source/generate.rst
+++ b/docs/source/generate.rst
@@ -24,9 +24,13 @@ Node
         .readFileSync(path.resolve(__dirname, 'input.docx'), 'binary');
 
     var zip = new PizZip(content);
-
-    var doc = new Docxtemplater(zip);
-
+    var doc;
+    try {
+        doc = new Docxtemplater(zip);
+    } catch(error) {
+        errorHandler(error);
+    }
+    
     //set the templateVariables
     doc.setData({
         first_name: 'John',
@@ -40,6 +44,10 @@ Node
         doc.render()
     }
     catch (error) {
+        errorHandler(error);
+    }
+
+    function errorHandler(error) {
         // The error thrown here contains additional information when logged with JSON.stringify (it contains a properties object containing all suberrors).
         function replaceErrors(key, value) {
             if (value instanceof Error) {
@@ -100,7 +108,13 @@ Browser
             loadFile("https://docxtemplater.com/tag-example.docx",function(error,content){
                 if (error) { throw error };
                 var zip = new PizZip(content);
-                var doc=new window.docxtemplater(zip);
+                var doc;
+                try {
+                    doc=new window.docxtemplater(zip);
+                } catch(error) {
+                    errorHandler(error);
+                }
+                
                 doc.setData({
                     first_name: 'John',
                     last_name: 'Doe',
@@ -109,9 +123,13 @@ Browser
                 });
                 try {
                     // render the document (replace all occurences of {first_name} by John, {last_name} by Doe, ...)
-                    doc.render()
+                    doc.render();
                 }
                 catch (error) {
+                    errorHandler(error);
+                }
+
+                function errorHandler(error) {
                     // The error thrown here contains additional information when logged with JSON.stringify (it contains a properties object containing all suberrors).
                     function replaceErrors(key, value) {
                         if (value instanceof Error) {
@@ -134,6 +152,7 @@ Browser
                     }
                     throw error;
                 }
+
                 var out=doc.getZip().generate({
                     type:"blob",
                     mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",

--- a/es6/docxtemplater.js
+++ b/es6/docxtemplater.js
@@ -28,7 +28,7 @@ const {
 const currentModuleApiVersion = [3, 21, 0];
 
 const Docxtemplater = class Docxtemplater {
-	constructor(zip, { modules = [] } = {}) {
+	constructor(zip, { modules = [], ...options } = {}) {
 		if (!Array.isArray(modules)) {
 			throw new Error(
 				"The modules argument of docxtemplater's constructor must be an array"
@@ -36,7 +36,7 @@ const Docxtemplater = class Docxtemplater {
 		}
 		this.compiled = {};
 		this.modules = [commonModule()];
-		this.setOptions({});
+		this.setOptions(options);
 		modules.forEach(module => {
 			this.attachModule(module);
 		});

--- a/es6/docxtemplater.js
+++ b/es6/docxtemplater.js
@@ -29,12 +29,6 @@ const currentModuleApiVersion = [3, 21, 0];
 
 const Docxtemplater = class Docxtemplater {
 	constructor(zip, { modules = [] } = {}) {
-		if (zip) {
-			if (!zip.files || typeof zip.file !== "function") {
-				throw new Error("The first argument of docxtemplater's constructor must be a valid zip file (jszip v2 or pizzip v3)");
-			}
-		}
-
 		if (!Array.isArray(modules)) {
 			throw new Error(
 				"The modules argument of docxtemplater's constructor must be an array"
@@ -47,6 +41,11 @@ const Docxtemplater = class Docxtemplater {
 			this.attachModule(module);
 		});
 		if (zip) {
+			if (!zip.files || typeof zip.file !== "function") {
+				throw new Error(
+					"The first argument of docxtemplater's constructor must be a valid zip file (jszip v2 or pizzip v3)"
+				);
+			}
 			this.loadZip(zip).compile();
 		}
 	}

--- a/es6/docxtemplater.js
+++ b/es6/docxtemplater.js
@@ -29,19 +29,18 @@ const currentModuleApiVersion = [3, 21, 0];
 
 const Docxtemplater = class Docxtemplater {
 	constructor(zip, { modules = [] } = {}) {
-		if (arguments.length > 0 && !zip && modules.length === 0) {
+		if (!Array.isArray(modules)) {
 			throw new Error(
-				"You should add zip and modules as the arguments, please check the v4 version guide."
+				"Please pass modules as an array"
 			);
 		}
 		this.compiled = {};
 		this.modules = [commonModule()];
 		this.setOptions({});
-
-		if (zip && modules.length > 0) {
-			modules.forEach(module => {
-				this.attachModule(module);
-			});
+		modules.forEach(module => {
+			this.attachModule(module);
+		});
+		if (zip) {
 			this.loadZip(zip);
 			this.compile();
 		}

--- a/es6/docxtemplater.js
+++ b/es6/docxtemplater.js
@@ -31,7 +31,7 @@ const Docxtemplater = class Docxtemplater {
 	constructor(zip, { modules = [] } = {}) {
 		if (!Array.isArray(modules)) {
 			throw new Error(
-				"Please pass modules as an array"
+				"The modules argument of docxtemplater's constructor must be an array"
 			);
 		}
 		this.compiled = {};
@@ -41,8 +41,7 @@ const Docxtemplater = class Docxtemplater {
 			this.attachModule(module);
 		});
 		if (zip) {
-			this.loadZip(zip);
-			this.compile();
+			this.loadZip(zip).compile();
 		}
 	}
 	getModuleApiVersion() {

--- a/es6/docxtemplater.js
+++ b/es6/docxtemplater.js
@@ -29,6 +29,12 @@ const currentModuleApiVersion = [3, 21, 0];
 
 const Docxtemplater = class Docxtemplater {
 	constructor(zip, { modules = [] } = {}) {
+		if (zip) {
+			if (!zip.files || typeof zip.file !== "function") {
+				throw new Error("The first argument of docxtemplater's constructor must be a valid zip file (jszip v2 or pizzip v3)");
+			}
+		}
+
 		if (!Array.isArray(modules)) {
 			throw new Error(
 				"The modules argument of docxtemplater's constructor must be an array"

--- a/es6/docxtemplater.js
+++ b/es6/docxtemplater.js
@@ -28,15 +28,23 @@ const {
 const currentModuleApiVersion = [3, 21, 0];
 
 const Docxtemplater = class Docxtemplater {
-	constructor() {
-		if (arguments.length > 0) {
+	constructor(zip, { modules = [] } = {}) {
+		if (arguments.length > 0 && !zip && modules.length === 0) {
 			throw new Error(
-				"The constructor with parameters has been removed in docxtemplater 3, please check the upgrade guide."
+				"You should add zip and modules as the arguments, please check the v4 version guide."
 			);
 		}
 		this.compiled = {};
 		this.modules = [commonModule()];
 		this.setOptions({});
+
+		if (zip && modules.length > 0) {
+			modules.forEach(module => {
+				this.attachModule(module);
+			});
+			this.loadZip(zip);
+			this.compile();
+		}
 	}
 	getModuleApiVersion() {
 		return currentModuleApiVersion.join(".");

--- a/es6/tests/base.js
+++ b/es6/tests/base.js
@@ -12,6 +12,7 @@ const {
 	expectToThrow,
 	getContent,
 	createDocV4,
+	getZip,
 } = require("./utils");
 const inspectModule = require("../inspect-module.js");
 
@@ -948,9 +949,7 @@ describe("Docxtemplater v4 tests", function() {
 	});
 
 	it("should render correctly using the new constructor", () => {
-		const docForZip = createDoc("tag-example.docx");
-		const zip = new PizZip(docForZip.loadedContent);
-		const doc = new Docxtemplater(zip);
+		const doc = new Docxtemplater(getZip("tag-example.docx"));
 		const tags = {
 			first_name: "John",
 			last_name: "Doe",

--- a/es6/tests/base.js
+++ b/es6/tests/base.js
@@ -931,62 +931,16 @@ describe("Serialization", function() {
 
 describe("Docxtemplater v4 tests", function() {
 	it("should work with new constructor", function() {
-		let xmlDocuments;
+		let isModuleCalled = false;
 
 		const module = {
-			requiredAPIVersion: "3.0.0",
-			optionsTransformer(options, docxtemplater) {
-				const relsFiles = docxtemplater.zip
-					.file(/document.xml.rels/)
-					.map(file => file.name);
-				options.xmlFileNames = options.xmlFileNames.concat(relsFiles);
+			optionsTransformer(options) {
+				isModuleCalled = true;
 				return options;
-			},
-			set(options) {
-				if (options.xmlDocuments) {
-					xmlDocuments = options.xmlDocuments;
-				}
 			},
 		};
 
-		const moduleV4Templater = {
-			requiredAPIVersion: "3.0.0",
-			optionsTransformer(options, docxtemplater) {
-				const relsFiles = docxtemplater.zip
-					.file(/document.xml.rels/)
-					.map(file => file.name);
-				options.xmlFileNames = options.xmlFileNames.concat(relsFiles);
-				return options;
-			},
-			set(options) {
-				if (options.xmlDocuments) {
-					xmlDocuments = options.xmlDocuments;
-				}
-			},
-		};
-
-		const doc = createDoc("tag-example.docx");
-		doc.attachModule(module);
-		doc.compile();
-		doc.render();
-
-		// create new docxTemplater with new constructor
-		const docV4Templater = createDocV4(doc.getZip(), { modules: [moduleV4Templater] });
-		const xmlKeys = Object.keys(xmlDocuments);
-		expect(xmlKeys).to.deep.equal(["word/_rels/document.xml.rels"]);
-		const rels = xmlDocuments[
-			"word/_rels/document.xml.rels"
-		].getElementsByTagName("Relationship");
-		expect(rels.length).to.equal(10);
-		const str = xml2str(xmlDocuments["word/_rels/document.xml.rels"]);
-
-		if (isNode12()) {
-			expect(str).to
-				.equal(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\r
-<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId8" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer" Target="footer1.xml"/><Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/settings" Target="settings.xml"/><Relationship Id="rId7" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/header" Target="header1.xml"/><Relationship Id="rId2" Type="http://schemas.microsoft.com/office/2007/relationships/stylesWithEffects" Target="stylesWithEffects.xml"/><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/><Relationship Id="rId6" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/endnotes" Target="endnotes.xml"/><Relationship Id="rId5" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes" Target="footnotes.xml"/><Relationship Id="rId10" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme" Target="theme/theme1.xml"/><Relationship Id="rId4" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/webSettings" Target="webSettings.xml"/><Relationship Id="rId9" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/fontTable" Target="fontTable.xml"/></Relationships>`);
-			rels[5].setAttribute("Foobar", "Baz");
-			docV4Templater.render();
-			shouldBeSame({ doc: docV4Templater, expectedName: "expected-module-change-rels.docx" });
-		}
+		createDocV4("tag-example.docx", { modules: [module] });
+		expect(isModuleCalled).to.equal(true);
 	});
 });

--- a/es6/tests/base.js
+++ b/es6/tests/base.js
@@ -11,7 +11,11 @@ const {
 	createDoc,
 	expectToThrow,
 	getContent,
+	createDocV4,
+	shouldBeSame,
+	isNode12,
 } = require("./utils");
+const { xml2str } = require("../doc-utils");
 const inspectModule = require("../inspect-module.js");
 
 function getLength(obj) {
@@ -922,5 +926,67 @@ describe("Serialization", function() {
 	it("should be serialiazable (useful for logging)", function() {
 		const doc = createDoc("tag-example.docx");
 		JSON.stringify(doc);
+	});
+});
+
+describe("Docxtemplater v4 tests", function() {
+	it("should work with new constructor", function() {
+		let xmlDocuments;
+
+		const module = {
+			requiredAPIVersion: "3.0.0",
+			optionsTransformer(options, docxtemplater) {
+				const relsFiles = docxtemplater.zip
+					.file(/document.xml.rels/)
+					.map(file => file.name);
+				options.xmlFileNames = options.xmlFileNames.concat(relsFiles);
+				return options;
+			},
+			set(options) {
+				if (options.xmlDocuments) {
+					xmlDocuments = options.xmlDocuments;
+				}
+			},
+		};
+
+		const moduleV4Templater = {
+			requiredAPIVersion: "3.0.0",
+			optionsTransformer(options, docxtemplater) {
+				const relsFiles = docxtemplater.zip
+					.file(/document.xml.rels/)
+					.map(file => file.name);
+				options.xmlFileNames = options.xmlFileNames.concat(relsFiles);
+				return options;
+			},
+			set(options) {
+				if (options.xmlDocuments) {
+					xmlDocuments = options.xmlDocuments;
+				}
+			},
+		};
+
+		const doc = createDoc("tag-example.docx");
+		doc.attachModule(module);
+		doc.compile();
+		doc.render();
+
+		// create new docxTemplater with new constructor
+		const docV4Templater = createDocV4(doc.getZip(), { modules: [moduleV4Templater] });
+		const xmlKeys = Object.keys(xmlDocuments);
+		expect(xmlKeys).to.deep.equal(["word/_rels/document.xml.rels"]);
+		const rels = xmlDocuments[
+			"word/_rels/document.xml.rels"
+		].getElementsByTagName("Relationship");
+		expect(rels.length).to.equal(10);
+		const str = xml2str(xmlDocuments["word/_rels/document.xml.rels"]);
+
+		if (isNode12()) {
+			expect(str).to
+				.equal(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\r
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId8" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer" Target="footer1.xml"/><Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/settings" Target="settings.xml"/><Relationship Id="rId7" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/header" Target="header1.xml"/><Relationship Id="rId2" Type="http://schemas.microsoft.com/office/2007/relationships/stylesWithEffects" Target="stylesWithEffects.xml"/><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/><Relationship Id="rId6" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/endnotes" Target="endnotes.xml"/><Relationship Id="rId5" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes" Target="footnotes.xml"/><Relationship Id="rId10" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme" Target="theme/theme1.xml"/><Relationship Id="rId4" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/webSettings" Target="webSettings.xml"/><Relationship Id="rId9" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/fontTable" Target="fontTable.xml"/></Relationships>`);
+			rels[5].setAttribute("Foobar", "Baz");
+			docV4Templater.render();
+			shouldBeSame({ doc: docV4Templater, expectedName: "expected-module-change-rels.docx" });
+		}
 	});
 });

--- a/es6/tests/base.js
+++ b/es6/tests/base.js
@@ -951,7 +951,16 @@ describe("Docxtemplater v4 tests", function() {
 	it("should throw an error when an invalid zip is passed", function() {
 		const zip = getZip("tag-example.docx");
 		zip.files = null;
+
 		expect(() => new Docxtemplater(zip)).to.throw(
+			"The first argument of docxtemplater's constructor must be a valid zip file (jszip v2 or pizzip v3)"
+		);
+
+		expect(() => new Docxtemplater("content")).to.throw(
+			"The first argument of docxtemplater's constructor must be a valid zip file (jszip v2 or pizzip v3)"
+		);
+
+		expect(() => new Docxtemplater(Buffer.from("content"))).to.throw(
 			"The first argument of docxtemplater's constructor must be a valid zip file (jszip v2 or pizzip v3)"
 		);
 	});

--- a/es6/tests/base.js
+++ b/es6/tests/base.js
@@ -944,7 +944,15 @@ describe("Docxtemplater v4 tests", function() {
 
 	it("should throw error when modules passed is not an array", function() {
 		expect(createDocV4.bind(this, "tag-example.docx", { modules: {} })).to.throw(
-			"Please pass modules as an array"
+			"The modules argument of docxtemplater's constructor must be an array"
+		);
+	});
+
+	it("should throw error when a valid zip is not passed", function() {
+		const zip = getZip("tag-example.docx");
+		zip.files = null;
+		expect(() => new Docxtemplater(zip)).to.throw(
+			"The first argument of docxtemplater's constructor must be a valid zip file (jszip v2 or pizzip v3)"
 		);
 	});
 

--- a/es6/tests/base.js
+++ b/es6/tests/base.js
@@ -942,13 +942,13 @@ describe("Docxtemplater v4 tests", function() {
 		expect(isModuleCalled).to.equal(true);
 	});
 
-	it("should throw error when modules passed is not an array", function() {
+	it("should throw an error when modules passed is not an array", function() {
 		expect(createDocV4.bind(this, "tag-example.docx", { modules: {} })).to.throw(
 			"The modules argument of docxtemplater's constructor must be an array"
 		);
 	});
 
-	it("should throw error when a valid zip is not passed", function() {
+	it("should throw an error when an invalid zip is passed", function() {
 		const zip = getZip("tag-example.docx");
 		zip.files = null;
 		expect(() => new Docxtemplater(zip)).to.throw(

--- a/es6/tests/base.js
+++ b/es6/tests/base.js
@@ -940,4 +940,10 @@ describe("Docxtemplater v4 tests", function() {
 		createDocV4("tag-example.docx", { modules: [module] });
 		expect(isModuleCalled).to.equal(true);
 	});
+
+	it("should throw error when modules passed is not an array", function() {
+		expect(createDocV4.bind(this, "tag-example.docx", { modules: {} })).to.throw(
+			"Please pass modules as an array"
+		);
+	});
 });

--- a/es6/tests/base.js
+++ b/es6/tests/base.js
@@ -946,4 +946,17 @@ describe("Docxtemplater v4 tests", function() {
 			"Please pass modules as an array"
 		);
 	});
+
+	it("should render correctly using the new constructor", () => {
+		const docForZip = createDoc("tag-example.docx");
+		const zip = new PizZip(docForZip.loadedContent);
+		const doc = new Docxtemplater(zip);
+		const tags = {
+			first_name: "John",
+			last_name: "Doe",
+		};
+		doc.setData(tags);
+		doc.render();
+		expect(doc.getFullText()).to.be.equal("Doe John");
+	});
 });

--- a/es6/tests/base.js
+++ b/es6/tests/base.js
@@ -12,10 +12,7 @@ const {
 	expectToThrow,
 	getContent,
 	createDocV4,
-	shouldBeSame,
-	isNode12,
 } = require("./utils");
-const { xml2str } = require("../doc-utils");
 const inspectModule = require("../inspect-module.js");
 
 function getLength(obj) {

--- a/es6/tests/base.js
+++ b/es6/tests/base.js
@@ -928,7 +928,7 @@ describe("Serialization", function() {
 });
 
 describe("Docxtemplater v4 tests", function() {
-	it("should work with new constructor", function() {
+	it("should work when modules are attached with new constructor", function() {
 		let isModuleCalled = false;
 
 		const module = {
@@ -963,6 +963,46 @@ describe("Docxtemplater v4 tests", function() {
 		expect(() => new Docxtemplater(Buffer.from("content"))).to.throw(
 			"The first argument of docxtemplater's constructor must be a valid zip file (jszip v2 or pizzip v3)"
 		);
+	});
+
+	it("should work when the delimiters are passed with new constructor", function() {
+		const options = {
+			delimiters: {
+				start: "<",
+				end: ">",
+			},
+		};
+		const doc = createDocV4("delimiter-gt.docx", options);
+		doc.setData({
+			user: "John",
+		});
+		doc.render();
+		const fullText = doc.getFullText();
+		expect(fullText).to.be.equal("Hello John");
+	});
+
+	it("should work with options object when both modules and delimiters are passed with new constructor", function() {
+		let isModuleCalled = false;
+		const options = {
+			delimiters: {
+				start: "<",
+				end: ">",
+			},
+			modules: [{
+				optionsTransformer(options) {
+					isModuleCalled = true;
+					return options;
+				},
+			}],
+		};
+		const doc = createDocV4("delimiter-gt.docx", options);
+		doc.setData({
+			user: "John",
+		});
+		doc.render();
+		const fullText = doc.getFullText();
+		expect(fullText).to.be.equal("Hello John");
+		expect(isModuleCalled).to.be.equal(true);
 	});
 
 	it("should render correctly using the new constructor", () => {

--- a/es6/tests/base.js
+++ b/es6/tests/base.js
@@ -927,8 +927,8 @@ describe("Serialization", function() {
 	});
 });
 
-describe("Docxtemplater v4 tests", function() {
-	it("should work when modules are attached with new constructor", function() {
+describe("Constructor v4", function() {
+	it("should work when modules are attached", function() {
 		let isModuleCalled = false;
 
 		const module = {
@@ -943,7 +943,9 @@ describe("Docxtemplater v4 tests", function() {
 	});
 
 	it("should throw an error when modules passed is not an array", function() {
-		expect(createDocV4.bind(this, "tag-example.docx", { modules: {} })).to.throw(
+		expect(
+			createDocV4.bind(this, "tag-example.docx", { modules: {} })
+		).to.throw(
 			"The modules argument of docxtemplater's constructor must be an array"
 		);
 	});
@@ -965,7 +967,7 @@ describe("Docxtemplater v4 tests", function() {
 		);
 	});
 
-	it("should work when the delimiters are passed with new constructor", function() {
+	it("should work when the delimiters are passed", function() {
 		const options = {
 			delimiters: {
 				start: "<",
@@ -981,31 +983,43 @@ describe("Docxtemplater v4 tests", function() {
 		expect(fullText).to.be.equal("Hello John");
 	});
 
-	it("should work with options object when both modules and delimiters are passed with new constructor", function() {
-		let isModuleCalled = false;
+	it("should work when both modules and delimiters are passed and modules should have access to options object", function() {
+		let isModuleCalled = false,
+			optionsPassedToModule;
 		const options = {
 			delimiters: {
-				start: "<",
-				end: ">",
+				start: "%",
+				end: "%",
 			},
-			modules: [{
-				optionsTransformer(options) {
-					isModuleCalled = true;
-					return options;
+			modules: [
+				{
+					optionsTransformer(options) {
+						optionsPassedToModule = options;
+						isModuleCalled = true;
+						return options;
+					},
 				},
-			}],
+			],
 		};
-		const doc = createDocV4("delimiter-gt.docx", options);
+		const doc = createDocV4("delimiter-pct.docx", options);
 		doc.setData({
 			user: "John",
+			company: "Acme",
 		});
-		doc.render();
-		const fullText = doc.getFullText();
-		expect(fullText).to.be.equal("Hello John");
+
 		expect(isModuleCalled).to.be.equal(true);
+		expect(optionsPassedToModule.delimiters.start).to.be.equal("%");
+		expect(optionsPassedToModule.delimiters.end).to.be.equal("%");
+		// Verify that default options are passed to the modules
+		expect(optionsPassedToModule.linebreaks).to.be.equal(false);
+
+		doc.render();
+
+		const fullText = doc.getFullText();
+		expect(fullText).to.be.equal("Hello John from Acme");
 	});
 
-	it("should render correctly using the new constructor", () => {
+	it("should render correctly", () => {
 		const doc = new Docxtemplater(getZip("tag-example.docx"));
 		const tags = {
 			first_name: "John",

--- a/es6/tests/utils.js
+++ b/es6/tests/utils.js
@@ -543,6 +543,10 @@ function createDoc(name) {
 	return loadDocument(name, documentCache[name].loadedContent);
 }
 
+function createDocV4(zip, { modules }) {
+	return new Docxtemplater(zip, { modules });
+}
+
 function getLoadedContent(name) {
 	return documentCache[name].loadedContent;
 }
@@ -593,4 +597,5 @@ module.exports = {
 	start,
 	wrapMultiError,
 	isNode12,
+	createDocV4,
 };

--- a/es6/tests/utils.js
+++ b/es6/tests/utils.js
@@ -544,12 +544,12 @@ function createDoc(name) {
 }
 
 function createDocV4(name, { modules }) {
-	const zip = documentCache[name].getZip();
+	const zip = getZip(name);
 	return new Docxtemplater(zip, { modules });
 }
 
 function getZip(name) {
-	return documentCache[name].getZip();
+	return new PizZip(documentCache[name].loadedContent);
 }
 
 function getLoadedContent(name) {

--- a/es6/tests/utils.js
+++ b/es6/tests/utils.js
@@ -543,7 +543,8 @@ function createDoc(name) {
 	return loadDocument(name, documentCache[name].loadedContent);
 }
 
-function createDocV4(zip, { modules }) {
+function createDocV4(name, { modules }) {
+	const zip = documentCache[name].getZip();
 	return new Docxtemplater(zip, { modules });
 }
 

--- a/es6/tests/utils.js
+++ b/es6/tests/utils.js
@@ -548,6 +548,10 @@ function createDocV4(name, { modules }) {
 	return new Docxtemplater(zip, { modules });
 }
 
+function getZip(name) {
+	return documentCache[name].getZip();
+}
+
 function getLoadedContent(name) {
 	return documentCache[name].loadedContent;
 }
@@ -599,4 +603,5 @@ module.exports = {
 	wrapMultiError,
 	isNode12,
 	createDocV4,
+	getZip,
 };

--- a/es6/tests/utils.js
+++ b/es6/tests/utils.js
@@ -543,9 +543,9 @@ function createDoc(name) {
 	return loadDocument(name, documentCache[name].loadedContent);
 }
 
-function createDocV4(name, { modules }) {
+function createDocV4(name, options) {
 	const zip = getZip(name);
-	return new Docxtemplater(zip, { modules });
+	return new Docxtemplater(zip, options);
 }
 
 function getZip(name) {


### PR DESCRIPTION
Changing the docxtemplater constructor API to v4.
This will support the two versions of the constructor:
-  Default constructor 
```
const doc = new Docxtemplater();
doc.attachModule(foomodule);
doc.attachModule(othermodule);
doc.loadZIp(zipFile);
doc.compile(); 
doc.setData({foo:"john"});
doc.render();
```
- v4 constructor
```
const doc = new Docxtemplater(zip, {modules: [ foomodule, othermodule ]})
doc.setData({foo:"john"});
doc.render();
```