### PR TITLE
feat: add capability to attach the supported modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,32 @@
 ### 3.17.1
+- Add support for automatically detaching modules that do not support the current filetype when using constructor v4. In previous versions, you would do the following:
 
-- Bugfix issue related to conditional attachment of modules. Some modules work with a particular file-type(docx, pptx). So, now when modules have a property `supportedFileTypes` listing the supported file types the constructor will attach only the valid modules.
+```
+let doc = new Docxtemplater();
+const zip = new PizZip(buffer)
+doc.loadZip(zip);
+
+if (doc.fileType === "pptx") {
+    doc.attachModule(new SlidesModule());
+}
+```
+
+Now it is possible to write instead the following, without needing the condition on filetype:
+
+```
+const zip = new PizZip(buffer)
+const options = {
+    modules: [new SlidesModule()],
+}
+try {
+   const doc = new Docxtemplater(zip, options);
+}
+catch (e) {
+    console.log(e);
+    // error handler
+}
+```
+
 - Update moduleApiVersion to 3.22.0.
 
 ### 3.17.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### 3.17.1
 
-- Bugfix issue related to conditional attachment of modules. Some modules work with a particular file-type(docx, pptx). So, now when modules have a property `supportedFileTypes` listing the supported file types the constructor will attach only the valid modules
-- Update moduleApiVersion to 3.22.0
+- Bugfix issue related to conditional attachment of modules. Some modules work with a particular file-type(docx, pptx). So, now when modules have a property `supportedFileTypes` listing the supported file types the constructor will attach only the valid modules.
+- Update moduleApiVersion to 3.22.0.
 
 ### 3.17.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 3.17.1
+
+- Bugfix issue related to conditional attachment of modules. Some modules work with a particular file-type(docx, pptx). So, now when modules have a property `supportedFileTypes` listing the supported file types the constructor will attach only the valid modules
+- Update moduleApiVersion to 3.22.0
+
 ### 3.17.0
 
 - Add a constructor method that accepts zip and optionally modules and other options. This constructor will be the official constructor in docxtemplater v4 and the methods: `loadZip`, `attachModule`, `setOptions` and `compile` will no more be available. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### 3.17.1
+
 - Add support for automatically detaching modules that do not support the current filetype when using constructor v4. In previous versions, you would do the following:
 
 ```
@@ -11,7 +12,7 @@ if (doc.fileType === "pptx") {
 }
 ```
 
-Now it is possible to write instead the following, without needing the condition on filetype:
+Now it is possible to write the following, without needing the condition on filetype:
 
 ```
 const zip = new PizZip(buffer)

--- a/es6/docxtemplater.js
+++ b/es6/docxtemplater.js
@@ -55,7 +55,8 @@ const Docxtemplater = class Docxtemplater {
 							"The supportedFileTypes field of the module must be an array"
 						);
 					}
-					const isSupportedModule = module.supportedFileTypes.indexOf(this.fileType) !== -1;
+					const isSupportedModule =
+						module.supportedFileTypes.indexOf(this.fileType) !== -1;
 					if (!isSupportedModule) {
 						module.on("detached");
 					}

--- a/es6/docxtemplater.js
+++ b/es6/docxtemplater.js
@@ -37,8 +37,8 @@ const Docxtemplater = class Docxtemplater {
 		this.compiled = {};
 		this.modules = [commonModule()];
 		this.setOptions(options);
-		modules.forEach(module => {
-			this.attachModule(module);
+		modules.forEach(mod => {
+			this.attachModule(mod);
 		});
 		if (zip) {
 			if (!zip.files || typeof zip.file !== "function") {
@@ -47,8 +47,8 @@ const Docxtemplater = class Docxtemplater {
 				);
 			}
 			this.loadZip(zip);
-			const detach = (module) => {
-				const indexOfModule = this.modules.indexOf(module);
+			const detach = (mod) => {
+				const indexOfModule = this.modules.indexOf(mod);
 				// module will always be present in the this.modules, hence we are not validating index.
 				const removedModule = this.modules.splice(indexOfModule, 1)[0];
 				removedModule.attached = false;
@@ -56,19 +56,19 @@ const Docxtemplater = class Docxtemplater {
 				return this;
 			};
 			// find the modules which are not supported
-			const toBeDetachedModules = this.modules.filter(module => {
-				if (module.supportedFileTypes) {
-					if (!Array.isArray(module.supportedFileTypes)) {
+			const toBeDetachedModules = this.modules.filter(mod => {
+				if (mod.supportedFileTypes) {
+					if (!Array.isArray(mod.supportedFileTypes)) {
 						throw new Error(
 							"The supportedFileTypes field of the module must be an array"
 						);
 					}
-					return !module.supportedFileTypes.includes(this.fileType);
+					return !mod.supportedFileTypes.includes(this.fileType);
 				}
 				return false;
 			});
-			toBeDetachedModules.forEach(module => {
-				detach(module);
+			toBeDetachedModules.forEach(mod => {
+				detach(mod);
 			});
 			this.compile();
 		}

--- a/es6/docxtemplater.js
+++ b/es6/docxtemplater.js
@@ -55,7 +55,7 @@ const Docxtemplater = class Docxtemplater {
 							"The supportedFileTypes field of the module must be an array"
 						);
 					}
-					const isSupportedModule = module.supportedFileTypes.includes(this.fileType);
+					const isSupportedModule = module.supportedFileTypes.indexOf(this.fileType) !== -1;
 					if (!isSupportedModule) {
 						module.on("detached");
 					}

--- a/es6/docxtemplater.js
+++ b/es6/docxtemplater.js
@@ -46,7 +46,31 @@ const Docxtemplater = class Docxtemplater {
 					"The first argument of docxtemplater's constructor must be a valid zip file (jszip v2 or pizzip v3)"
 				);
 			}
-			this.loadZip(zip).compile();
+			this.loadZip(zip);
+			const detach = () => {
+				const indexOfModule = this.modules.indexOf(module);
+				// module will always be present in the this.modules, hence we are not validating index.
+				const removedModule = this.modules.splice(indexOfModule, 1)[0];
+				removedModule.attached = false;
+				removedModule.on("detached");
+				return this;
+			};
+			// find the modules which are not supported
+			const toBeDetachedModules = this.modules.filter(module => {
+				if (module.supportedFileTypes) {
+					if (!Array.isArray(module.supportedFileTypes)) {
+						throw new Error(
+							"The supportedFileTypes field of the module must be an array"
+						);
+					}
+					return !module.supportedFileTypes.includes(this.fileType);
+				}
+				return false;
+			});
+			toBeDetachedModules.forEach(module => {
+				detach(module);
+			});
+			this.compile();
 		}
 	}
 	getModuleApiVersion() {

--- a/es6/docxtemplater.js
+++ b/es6/docxtemplater.js
@@ -25,7 +25,7 @@ const {
 	throwApiVersionError,
 } = require("./errors");
 
-const currentModuleApiVersion = [3, 21, 0];
+const currentModuleApiVersion = [3, 22, 0];
 
 const Docxtemplater = class Docxtemplater {
 	constructor(zip, { modules = [], ...options } = {}) {

--- a/es6/docxtemplater.js
+++ b/es6/docxtemplater.js
@@ -47,7 +47,7 @@ const Docxtemplater = class Docxtemplater {
 				);
 			}
 			this.loadZip(zip);
-			const detach = () => {
+			const detach = (module) => {
 				const indexOfModule = this.modules.indexOf(module);
 				// module will always be present in the this.modules, hence we are not validating index.
 				const removedModule = this.modules.splice(indexOfModule, 1)[0];

--- a/es6/docxtemplater.js
+++ b/es6/docxtemplater.js
@@ -37,8 +37,8 @@ const Docxtemplater = class Docxtemplater {
 		this.compiled = {};
 		this.modules = [commonModule()];
 		this.setOptions(options);
-		modules.forEach(mod => {
-			this.attachModule(mod);
+		modules.forEach(module => {
+			this.attachModule(module);
 		});
 		if (zip) {
 			if (!zip.files || typeof zip.file !== "function") {
@@ -47,28 +47,21 @@ const Docxtemplater = class Docxtemplater {
 				);
 			}
 			this.loadZip(zip);
-			const detach = (mod) => {
-				const indexOfModule = this.modules.indexOf(mod);
-				// module will always be present in the this.modules, hence we are not validating index.
-				const removedModule = this.modules.splice(indexOfModule, 1)[0];
-				removedModule.attached = false;
-				removedModule.on("detached");
-				return this;
-			};
-			// find the modules which are not supported
-			const toBeDetachedModules = this.modules.filter(mod => {
-				if (mod.supportedFileTypes) {
-					if (!Array.isArray(mod.supportedFileTypes)) {
+			// remove the unsupported modules
+			this.modules = this.modules.filter(module => {
+				if (module.supportedFileTypes) {
+					if (!Array.isArray(module.supportedFileTypes)) {
 						throw new Error(
 							"The supportedFileTypes field of the module must be an array"
 						);
 					}
-					return !mod.supportedFileTypes.includes(this.fileType);
+					const isSupportedModule = module.supportedFileTypes.includes(this.fileType);
+					if (!isSupportedModule) {
+						module.on("detached");
+					}
+					return isSupportedModule;
 				}
-				return false;
-			});
-			toBeDetachedModules.forEach(mod => {
-				detach(mod);
+				return true;
 			});
 			this.compile();
 		}

--- a/es6/tests/base.js
+++ b/es6/tests/base.js
@@ -99,7 +99,7 @@ describe("Api versioning", function() {
 				name: "APIVersionError",
 				properties: {
 					id: "api_version_error",
-					currentModuleApiVersion: [3, 21, 0],
+					currentModuleApiVersion: [3, 22, 0],
 					neededVersion: [5, 6, 0],
 				},
 			}
@@ -114,7 +114,7 @@ describe("Api versioning", function() {
 				name: "APIVersionError",
 				properties: {
 					id: "api_version_error",
-					currentModuleApiVersion: [3, 21, 0],
+					currentModuleApiVersion: [3, 22, 0],
 					neededVersion: [3, 44, 0],
 				},
 			}

--- a/es6/tests/base.js
+++ b/es6/tests/base.js
@@ -1029,4 +1029,19 @@ describe("Constructor v4", function() {
 		doc.render();
 		expect(doc.getFullText()).to.be.equal("Doe John");
 	});
+
+	it("should work when modules are attached with valid filetypes", function() {
+		let isModuleCalled = false;
+
+		const module = {
+			optionsTransformer(options) {
+				isModuleCalled = true;
+				return options;
+			},
+			supportedFileTypes: ["pptx", "docx"],
+		};
+
+		createDocV4("tag-example.docx", { modules: [module] });
+		expect(isModuleCalled).to.equal(true);
+	});
 });

--- a/es6/tests/base.js
+++ b/es6/tests/base.js
@@ -1032,7 +1032,6 @@ describe("Constructor v4", function() {
 
 	it("should work when modules are attached with valid filetypes", function() {
 		let isModuleCalled = false;
-
 		const module = {
 			optionsTransformer(options) {
 				isModuleCalled = true;
@@ -1040,7 +1039,6 @@ describe("Constructor v4", function() {
 			},
 			supportedFileTypes: ["pptx", "docx"],
 		};
-
 		createDocV4("tag-example.docx", { modules: [module] });
 		expect(isModuleCalled).to.equal(true);
 	});

--- a/es6/tests/base.js
+++ b/es6/tests/base.js
@@ -1044,4 +1044,17 @@ describe("Constructor v4", function() {
 		createDocV4("tag-example.docx", { modules: [module] });
 		expect(isModuleCalled).to.equal(true);
 	});
+
+	it("should throw an error when supportedFieldType property in passed module is not an Array", function() {
+		const zip = getZip("tag-example.docx");
+		const module = {
+			optionsTransformer(options) {
+				return options;
+			},
+			supportedFileTypes: "pptx",
+		};
+		expect(() => new Docxtemplater(zip, { modules: [module] })).to.throw(
+			"The supportedFileTypes field of the module must be an array"
+		);
+	});
 });

--- a/es6/tests/modules.js
+++ b/es6/tests/modules.js
@@ -253,19 +253,3 @@ describe("Module detachment", function() {
 		expect(isModuleCalled).to.equal(false);
 	});
 });
-
-describe("Module supportedFieldType property", function() {
-	it("should throw error when supportedFieldType is not an Array", function() {
-		const zip = getZip("tag-example.docx");
-		const module = {
-			optionsTransformer(options) {
-				return options;
-			},
-			supportedFileTypes: "pptx",
-		};
-		expect(() => new Docxtemplater(zip, { modules: [module] })).to.throw(
-			"The supportedFileTypes field of the module must be an array"
-		);
-	});
-});
-

--- a/es6/tests/modules.js
+++ b/es6/tests/modules.js
@@ -4,12 +4,10 @@ const {
 	shouldBeSame,
 	isNode12,
 	createDocV4,
-	getZip,
 } = require("./utils");
 const Errors = require("../errors.js");
 const { expect } = require("chai");
 const { xml2str, traits } = require("../doc-utils");
-const Docxtemplater = require("../docxtemplater.js");
 
 describe("Verify apiversion", function() {
 	it("should work with valid api version", function() {

--- a/es6/tests/modules.js
+++ b/es6/tests/modules.js
@@ -233,35 +233,14 @@ describe("Module errors", function() {
 });
 
 describe("Module detachment", function() {
-	it("should detach the module when file is not in its supported types", function() {
-		const module = {
-			optionsTransformer(options) {
-				return options;
-			},
-			supportedFileTypes: ["pptx"],
-		};
-		const doc = createDocV4("tag-example.docx", { modules: [module] });
-		expect(doc.modules.length).to.equal(6);
-	});
-
-	it("module should not be called", function() {
+	it("should detach the module when the module does not support the document filetype", function() {
 		let isModuleCalled = false;
-
+		let isDetachedCalled = false;
 		const module = {
 			optionsTransformer(options) {
 				isModuleCalled = true;
 				return options;
 			},
-			supportedFileTypes: ["pptx"],
-		};
-
-		createDocV4("tag-example.docx", { modules: [module] });
-		expect(isModuleCalled).to.equal(false);
-	});
-
-	it("detached event should be called", function() {
-		let isDetachedCalled = false;
-		const module = {
 			on(eventName) {
 				if(eventName === "detached") {
 					isDetachedCalled = true;
@@ -271,6 +250,7 @@ describe("Module detachment", function() {
 		};
 		createDocV4("tag-example.docx", { modules: [module] });
 		expect(isDetachedCalled).to.equal(true);
+		expect(isModuleCalled).to.equal(false);
 	});
 });
 

--- a/es6/tests/modules.js
+++ b/es6/tests/modules.js
@@ -14,7 +14,7 @@ const Docxtemplater = require("../docxtemplater.js");
 describe("Verify apiversion", function() {
 	it("should work with valid api version", function() {
 		const module = {
-			requiredAPIVersion: "3.21.0",
+			requiredAPIVersion: "3.22.0",
 			render(part) {
 				return part.value;
 			},
@@ -38,7 +38,7 @@ describe("Verify apiversion", function() {
 			name: "APIVersionError",
 			properties: {
 				id: "api_version_error",
-				currentModuleApiVersion: [3, 21, 0],
+				currentModuleApiVersion: [3, 22, 0],
 				neededVersion: [3, 92, 0],
 			},
 		});

--- a/es6/tests/modules.js
+++ b/es6/tests/modules.js
@@ -240,7 +240,7 @@ describe("Module detachment", function() {
 				return options;
 			},
 			on(eventName) {
-				if(eventName === "detached") {
+				if (eventName === "detached") {
 					isDetachedCalled = true;
 				}
 			},


### PR DESCRIPTION
## Description
In the recent update of Docxtemplater version, it was not possible to conditionally attach the module. With this PR, only the compatible modules will be attached while constructing Docxtemplater instance.

closes #499 