### PR TITLE
Fixed Issue#516

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -60,12 +60,28 @@ Methods
 
         This function replaces all template variables by their values
 
-    compile()
-
-        This function is deprecated and you should instead use the new constructor with two arguments.
-        This function parses the template to prepare for the rendering. If your template has some issues in the syntax (for example if your tag is never closed like in : `Hello {user`), this function will throw an error with extra properties describing the error. This function is called for you in render() if you didn't call it yourself. This function should be called before doing resolveData() if you have some async data.
-
     getZip()
 
         This will return you the zip that represents the docx. You can then call `.generate` on this to generate a buffer, string , ... (see https://github.com/open-xml-templating/pizzip/blob/master/documentation/api_pizzip/generate.md)
         
+    compile()
+
+        This function is **deprecated** and you should instead use the new constructor with two arguments.
+        This function parses the template to prepare for the rendering. If your template has some issues in the syntax (for example if your tag is never closed like in : `Hello {user`), this function will throw an error with extra properties describing the error. This function is called for you in render() if you didn't call it yourself. This function should be called before doing resolveData() if you have some async data.
+
+    loadZip(zip)
+
+        This function is **deprecated** and you should instead use the new constructor with two arguments.
+        You have to pass a zip instance to that method, coming from pizzip or jszip version 2
+
+    setOptions()
+
+        This function is **deprecated** and you should instead use the new constructor with two arguments.
+        This function is used to configure the docxtemplater instance by changing parser, delimiters, etc. (See https://docxtemplater.readthedocs.io/en/latest/configuration.html).
+
+    attachModule(module)
+
+        This function is **deprecated** and you should instead use the new constructor with two arguments.
+        This will attach a module to the docxtemplater instance, which is usually used to add new generation features (possibility to include images, HTML, ...). Pro modules can be bought on https://docxtemplater.com/
+
+        This method can be called multiple times, for example : `doc.loadZip(zip).attachModule(imageModule).attachModule(htmlModule)`

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -60,11 +60,6 @@ Methods
 
         This function replaces all template variables by their values
 
-    loadZip(zip)
-
-        This function is deprecated and you should instead use the new constructor with two arguments.
-        You have to pass a zip instance to that method, coming from pizzip or jszip version 2
-
     compile()
 
         This function is deprecated and you should instead use the new constructor with two arguments.

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -74,11 +74,6 @@ Methods
 
         This will return you the zip that represents the docx. You can then call `.generate` on this to generate a buffer, string , ... (see https://github.com/open-xml-templating/pizzip/blob/master/documentation/api_pizzip/generate.md)
 
-    setOptions()
-
-        This function is deprecated and you should instead use the new constructor with two arguments.
-        This function is used to configure the docxtemplater instance by changing parser, delimiters, etc. (See https://docxtemplater.readthedocs.io/en/latest/configuration.html).
-
     attachModule(module)
 
         This function is deprecated and you should instead use the new constructor with two arguments.

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -73,10 +73,4 @@ Methods
     getZip()
 
         This will return you the zip that represents the docx. You can then call `.generate` on this to generate a buffer, string , ... (see https://github.com/open-xml-templating/pizzip/blob/master/documentation/api_pizzip/generate.md)
-
-    attachModule(module)
-
-        This function is deprecated and you should instead use the new constructor with two arguments.
-        This will attach a module to the docxtemplater instance, which is usually used to add new generation features (possibility to include images, HTML, ...). Pro modules can be bought on https://docxtemplater.com/
-
-        This method can be called multiple times, for example : `doc.loadZip(zip).attachModule(imageModule).attachModule(htmlModule)`
+        

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -121,7 +121,7 @@ It is possible to customize the value that will be shown for {name} by using the
         }
         return "";
     }
-    const doc = new Docxtemplater(zip, {nullGetter: nullGetter,});
+    const doc = new Docxtemplater(zip, {nullGetter: nullGetter});
 
 Performance
 -----------
@@ -793,7 +793,7 @@ And each user block will be followed by a pagebreak, except the last user.
         return angularParser(tag);
     }
     const doc = new Docxtemplater();
-    const doc = new Docxtemplater(zip, {parser: parser,});
+    const doc = new Docxtemplater(zip, {parser: parser});
     doc.render();
 
 Assignment expression in template

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -30,13 +30,13 @@ The size of the docx output can be big, in the case where you generate the zip t
 
 .. code-block:: javascript
 
-    docx.getZip().generate({ type: "nodebuffer"})
+    doc.getZip().generate({ type: "nodebuffer"})
 
 This is because the zip will not be compressed in that case. To force the compression (which could be slow because it is running in JS for files bigger than 10 MB)
 
 .. code-block:: javascript
 
-    var zip = docx.getZip().generate({
+    var zip = doc.getZip().generate({
             type: "nodebuffer",
             compression: "DEFLATE"
     });

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -792,7 +792,6 @@ And each user block will be followed by a pagebreak, except the last user.
         // https://docxtemplater.readthedocs.io/en/latest/configuration.html#default-parser
         return angularParser(tag);
     }
-    const doc = new Docxtemplater();
     const doc = new Docxtemplater(zip, {parser: parser});
     doc.render();
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -121,9 +121,7 @@ It is possible to customize the value that will be shown for {name} by using the
         }
         return "";
     }
-    doc.setOptions({
-        nullGetter: nullGetter,
-    });
+    const doc = new Docxtemplater(zip, {nullGetter: nullGetter,});
 
 Performance
 -----------
@@ -795,10 +793,7 @@ And each user block will be followed by a pagebreak, except the last user.
         return angularParser(tag);
     }
     const doc = new Docxtemplater();
-    doc.setOptions({
-        parser: parser
-    });
-    doc.loadZip(zip);
+    const doc = new Docxtemplater(zip, {parser: parser,});
     doc.render();
 
 Assignment expression in template

--- a/docs/source/tag_types.rst
+++ b/docs/source/tag_types.rst
@@ -281,9 +281,9 @@ Here we have a list with three items. The first item uses the default tag style,
 
 Custom delimiters may not contain whitespace or the equals sign.
 
-It is also possible to `change the delimiters from docxtemplater.setOptions`_.
+It is also possible to `change the delimiters by using docxtemplater options object`_.
 
-.. _`change the delimiters from docxtemplater.setOptions`: configuration.html#custom-delimiters
+.. _`change the delimiters by using docxtemplater options object`: configuration.html#custom-delimiters
 
 Dash syntax
 -----------


### PR DESCRIPTION
Migrated doc to stop using the deprecated methods`setOptions`, `attachModule`, `loadZip`
All test cases are passing.