### PR TITLE
Add getFullText method of Docxtemplater

### DIFF
--- a/es6/docxtemplater.d.ts
+++ b/es6/docxtemplater.d.ts
@@ -108,6 +108,7 @@ declare class Docxtemplater {
     setOptions(options: DXT.Options): this
     attachModule(module: DXT.Module): this
     compile(): this
+    getFullText(): string
 }
 
 export default Docxtemplater;


### PR DESCRIPTION
Add getFullText method of Docxtemplater to the type definition

So that we do not have to cast instances of Docxtemplater to be able to use getFullText without typescript warnings.

e.g.

```
const doc = new Docxtemplater(documentZip)
doc.render()
const text = doc.getFullText()
```

instead of currently having to 

```
const doc = new Docxtemplater(documentZip)
doc.render()
const fullText = ((doc as unknown) as {
    getFullText: () => string
  }).getFullText()
```

Or similar.