### PR TITLE
update package @xmldom/xmldom to  0.8.3 due to Vulnerability in lower version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/open-xml-templating/docxtemplater"
   },
   "dependencies": {
-    "@xmldom/xmldom": "^0.8.2"
+    "@xmldom/xmldom": "^0.8.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.19.3",


### PR DESCRIPTION
*Prototype Pollution* Vulnerability in the package lower then 0.8.3

https://security.snyk.io/vuln/SNYK-JS-XMLDOMXMLDOM-3042243