### PR TITLE
Add footnotes.xml to the filetypes list

### DIFF
--- a/es6/filetypes.js
+++ b/es6/filetypes.js
@@ -8,6 +8,8 @@ const dotmContentType =
 	"application/vnd.ms-word.template.macroEnabledTemplate.main+xml";
 const headerContentType =
 	"application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml";
+const footnotesContentType =
+	"application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml";
 const footerContentType =
 	"application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml";
 
@@ -29,7 +31,7 @@ const main = [
 
 const filetypes = {
 	main,
-	docx: [...main, headerContentType, footerContentType],
+	docx: [...main, headerContentType, footerContentType, footnotesContentType],
 	pptx: [
 		pptxContentType,
 		pptxSlideMaster,

--- a/es6/tests/e2e/base.js
+++ b/es6/tests/e2e/base.js
@@ -72,6 +72,7 @@ describe("Retrieving list of templated files", function () {
 			"docProps/core.xml",
 			"word/document.xml",
 			"word/footer1.xml",
+			"word/footnotes.xml",
 			"word/header1.xml",
 			"word/settings.xml",
 		]);


### PR DESCRIPTION
### Issue description:

I was using docxtemplater in order to generate new documents while replacing tags with JSON data.
When I used a more complex document file, I noticed that the tags in the footnotes section were not being replaced.

And after some digging I found that the `footnotes.xml`  file that contains the footnotes body is not available in the `filetypes` object.

By simply adding the `footnotesContentType` to the list of file types, the library was able to support footnotes tags.

Here's a word document [(Footnote Demo.docx)](https://github.com/open-xml-templating/docxtemplater/files/10241611/Footnote.Demo.docx) containing a footnote with a tag that wont be replaced.
The document can be tested [here](https://docxtemplater.com/demo/#simple) using the following data:
`{
  "tag": "not working tag"
}`


