### PR TITLE
Remove `file` arg from `getAllStructuredTags` type

### DIFF
--- a/es6/inspect-module.d.ts
+++ b/es6/inspect-module.d.ts
@@ -23,7 +23,7 @@ export default class InspectModule implements DXT.Module {
   >;
 
   getStructuredTags(file: string): DXT.Part[];
-  getAllStructuredTags(file: string): DXT.Part[];
+  getAllStructuredTags(): DXT.Part[];
   getFileType(): string;
   getTemplatedFiles(): string[];
 }


### PR DESCRIPTION
Addresses the issue described in https://github.com/open-xml-templating/docxtemplater/issues/701

It makes the `getAllStructuredTags` type match the actual JS implementation defined in https://github.com/open-xml-templating/docxtemplater/blob/master/es6/inspect-module.js#L114