### PR TITLE
Made `zip` type generic

### DIFF
--- a/es6/docxtemplater.d.ts
+++ b/es6/docxtemplater.d.ts
@@ -97,14 +97,14 @@ export namespace DXT {
   }
 }
 
-declare class Docxtemplater {
+declare class Docxtemplater<TZip = any> {
   /**
    * Create Docxtemplater instance (and compile it on the fly)
    *
    * @param zip Serialized zip archive
-   * @param options modules and other other options
+   * @param options `modules` and other options
    */
-  constructor(zip: any, options?: DXT.ConstructorOptions);
+  constructor(zip: TZip, options?: DXT.ConstructorOptions);
   /**
    * Create Docxtemplater instance, without options
    */
@@ -114,9 +114,9 @@ declare class Docxtemplater {
   resolveData(data: any): Promise<any>;
   render(data?: any): this;
   renderAsync(data?: any): Promise<any>;
-  getZip(): any;
+  getZip(): TZip;
 
-  loadZip(zip: any): this;
+  loadZip(zip: TZip): this;
   setOptions(options: DXT.Options): this;
   attachModule(module: DXT.Module): this;
   compile(): this;


### PR DESCRIPTION
Previously, all the types of the `zip` were `any`. It doesn't allow using of the `PizZip` or other archivers with type confidence. And IDE pulls types from random places when you try using `getZip`: 
<img width="771" alt="image" src="https://user-images.githubusercontent.com/68850090/222771462-cf4fda29-2ef1-4c1b-a57b-435f9d93aa81.png">

In this PR I made the type of passed zip generic and inferrable which will improve the DX and will prevent `as PizZip` statements in the code.