### PR TITLE
Bugfix error in "undefined" argument

### DIFF
--- a/es6/scope-manager.js
+++ b/es6/scope-manager.js
@@ -38,7 +38,7 @@ function getValue(tag, meta, num) {
 	let result;
 
 	let parser;
-	if (!this.cachedParsers || !meta.part) {
+	if (!this.cachedParsers || !meta || !meta.part) {
 		parser = this.parser(tag, {
 			scopePath: this.scopePath,
 		});


### PR DESCRIPTION
This condition was added because when using the `docxtemplater-image-module` module, the `meta` argument is sometimes undefined.