### PR TITLE
Improve Support for TypeScript NodeNext/Node16 Module Resolution

### DIFF
--- a/es6/docxtemplater.d.ts
+++ b/es6/docxtemplater.d.ts
@@ -1,4 +1,4 @@
-export namespace DXT {
+declare namespace DXT {
   type integer = number;
 
   interface SimplePart {
@@ -98,6 +98,7 @@ export namespace DXT {
 }
 
 declare class Docxtemplater<TZip = any> {
+  static default: typeof Docxtemplater;
   /**
    * Create Docxtemplater instance (and compile it on the fly)
    *
@@ -125,4 +126,9 @@ declare class Docxtemplater<TZip = any> {
   replaceLastSection?: boolean; // used for the subsection module
 }
 
-export default Docxtemplater;
+declare namespace Docxtemplater {
+  export { DXT }
+}
+
+export = Docxtemplater;
+

--- a/es6/docxtemplater.js
+++ b/es6/docxtemplater.js
@@ -522,3 +522,4 @@ Docxtemplater.XmlTemplater = require("./xml-templater.js");
 Docxtemplater.FileTypeConfig = require("./file-type-config.js");
 Docxtemplater.XmlMatcher = require("./xml-matcher.js");
 module.exports = Docxtemplater;
+module.exports.default = Docxtemplater;


### PR DESCRIPTION
If you update your TypeScript settings to use the new NodeNext moduleResolution setting, you can't use the Docxtemplater class without add an extra `.default` access:

```
import Docxtemplater from "docxtemplater";

const d = new Docxtemplater.default();
```

This problem is explained more generally [here](https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/MissingExportEquals.md).

In Docxtemplater's case, this would likely crash at runtime, since there is no explicit `.default` property on the export.

This PR uses the recommended guidance to make the types compatible with NodeNext (confirmed still compatible with the previous non-NodeNext/Node16 resolution). It also adds an explicit `.default` attribute on the export for improved compatibility with those not using the TypeScript `esModuleInterop: true` setting.